### PR TITLE
move afterInstallation hook after data store operation

### DIFF
--- a/src/oauth-app.ts
+++ b/src/oauth-app.ts
@@ -389,16 +389,6 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
       });
     }
     const installation = toInstallation(oauthAccess);
-    if (this.oauth.afterInstallation) {
-      const response = await this.oauth.afterInstallation({
-        env: this.env,
-        request,
-        installation,
-      });
-      if (response) {
-        return response;
-      }
-    }
 
     try {
       // Store the installation data on this app side
@@ -411,6 +401,17 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
         reason: InstallationStoreError,
         request,
       });
+    }
+
+    if (this.oauth.afterInstallation) {
+      const response = await this.oauth.afterInstallation({
+        env: this.env,
+        request,
+        installation,
+      });
+      if (response) {
+        return response;
+      }
     }
 
     try {

--- a/src_deno/oauth-app.ts
+++ b/src_deno/oauth-app.ts
@@ -436,16 +436,6 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
       });
     }
     const installation = toInstallation(oauthAccess);
-    if (this.oauth.afterInstallation) {
-      const response = await this.oauth.afterInstallation({
-        env: this.env,
-        request,
-        installation,
-      });
-      if (response) {
-        return response;
-      }
-    }
 
     try {
       // Store the installation data on this app side
@@ -458,6 +448,17 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
         reason: InstallationStoreError,
         request,
       });
+    }
+
+    if (this.oauth.afterInstallation) {
+      const response = await this.oauth.afterInstallation({
+        env: this.env,
+        request,
+        installation,
+      });
+      if (response) {
+        return response;
+      }
     }
 
     try {


### PR DESCRIPTION
It seems to me the "installation" is only complete once the oauth has happened _and_ the installation data has successfully been saved in the data store. Thus, I am suggesting moving the custom `afterInstallation` hook _after_ the installation data has been stored. This allows the `afterInstallation` hook assumptions that it can reach into the data store (e.g. KV for cloudflare workers).

However, if that's not agreeable, I'm just as happy to introduce a new hook like `afterInstallationStore`.