### PR TITLE
add is_forgotten field to user_change event payload

### DIFF
--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1032,6 +1032,7 @@ export interface UserChangeEvent extends SlackEvent<"user_change"> {
     team_id: string;
     name: string;
     deleted: boolean;
+    is_forgotten?: boolean;
     color: string;
     real_name: string;
     tz: string;

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -1061,6 +1061,7 @@ export interface UserChangeEvent extends SlackEvent<"user_change"> {
     team_id: string;
     name: string;
     deleted: boolean;
+    is_forgotten?: boolean;
     color: string;
     real_name: string;
     tz: string;


### PR DESCRIPTION
Bringing parity between the `user_change` and `user_profile_changed` event payloads. They were identical in my testing.