### PR TITLE
Fix falsy check for empty tokens_revoked tokens arrays

### DIFF
--- a/src/oauth-app.ts
+++ b/src/oauth-app.ts
@@ -234,7 +234,7 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
 
   #enableTokenRevocationHandlers(installationStore: InstallationStore<E>) {
     this.event("tokens_revoked", async ({ payload, body }) => {
-      if (payload.tokens.bot) {
+      if (Array.isArray(payload.tokens.bot) && payload.tokens.bot.length > 0) {
         // actually only one bot per app in a workspace
         try {
           await installationStore.deleteBotInstallation({
@@ -245,7 +245,7 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
           console.log(`Failed to delete a bot installation (error: ${e})`);
         }
       }
-      if (payload.tokens.oauth) {
+      if (Array.isArray(payload.tokens.oauth) && payload.tokens.oauth.length > 0) {
         for (const userId of payload.tokens.oauth) {
           try {
             await installationStore.deleteUserInstallation({

--- a/src_deno/oauth-app.ts
+++ b/src_deno/oauth-app.ts
@@ -264,7 +264,7 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
 
   #enableTokenRevocationHandlers(installationStore: InstallationStore<E>) {
     this.event("tokens_revoked", async ({ payload, body }) => {
-      if (payload.tokens.bot) {
+      if (Array.isArray(payload.tokens.bot) && payload.tokens.bot.length > 0) {
         // actually only one bot per app in a workspace
         try {
           await installationStore.deleteBotInstallation({
@@ -275,7 +275,7 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
           console.log(`Failed to delete a bot installation (error: ${e})`);
         }
       }
-      if (payload.tokens.oauth) {
+      if (Array.isArray(payload.tokens.oauth) && payload.tokens.oauth.length > 0) {
         for (const userId of payload.tokens.oauth) {
           try {
             await installationStore.deleteUserInstallation({


### PR DESCRIPTION
# Background

The payload of `tokens_revoked` events look like so:
```js
{
    "type": "tokens_revoked",
    "tokens": {
      "oauth": [
        "U0680J3FQMS"
      ],
      "bot": []
    },
    "event_ts": "1754339555.617760"
}
```
Note that in the above example, the `oauth` tokens are user-level tokens and the `bot` tokens are are bot-level tokens. If either of the arrays are empty, we should leave those KV installation entries alone.

# Issue

https://github.com/slack-edge/slack-edge/blob/2a9dde02618679ff864da0f378248ccf5f6b32b0/src/oauth-app.ts#L237

`if (payload.tokens.bot)` is an incorrect way to check for these values since empty an array `[]` is still truthy in javascript. 😓  Darn you js.

The result is that even for user-level token revocations, the framework was incorrectly deleting the bot-level KV entry as well. With the bot-level entry missing, all future workspace Slack events would result in `not_authed` failures.

# Fix

Check the array presence and its length.

Note: This is at least one of the main root causes of the bug https://github.com/slack-edge/slack-cloudflare-workers/issues/20! 🎉 